### PR TITLE
feat: add configurable password validation with Joi and OWASP #2

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -24,3 +24,22 @@ ACCESS_SECRET_TOKEN=your-super-secret-jwt-token-here
 # Number of salt rounds for bcrypt password hashing (recommended: 10-12)
 # Higher numbers are more secure but slower
 BCRYPT_SALT=length-of-salt-comes-here
+
+# Password policies
+# Password Length
+PASSWORD_MIN_LENGTH=8
+PASSWORD_MAX_LENGTH=128
+
+# Character Requirements (minimum count for each type)
+PASSWORD_MIN_LOWERCASE=1
+PASSWORD_MIN_UPPERCASE=1
+PASSWORD_MIN_NUMBERS=1
+PASSWORD_MIN_SYMBOLS=1
+
+# Overall Complexity (how many of the above types are required)
+PASSWORD_REQUIREMENT_COUNT=3
+
+# Additional Security Features
+PASSWORD_BLOCK_COMMON=true
+PASSWORD_BLOCK_SEQUENTIAL=true
+PASSWORD_BLOCK_REPEATED=true

--- a/index.js
+++ b/index.js
@@ -8,9 +8,13 @@ import authenticationRoutes from "./routes/authentication.js";
 import userRoutes from "./routes/users.js";
 import blogRoutes from "./routes/blogs.js";
 import commentRoutes from "./routes/comments.js";
+import dotenv from 'dotenv';
 
 // All of our user defined middlewares
 import { authProtection, isSuperAdmin } from "./middlewares/authStrategy.js";
+
+// Load environment variables
+dotenv.config();
 
 // Configuring our Mongo database with mongoose
 configureMongoose();

--- a/middlewares/validateRegister.js
+++ b/middlewares/validateRegister.js
@@ -1,0 +1,29 @@
+import Joi from 'joi';
+import passwordComplexity from 'joi-password-complexity';
+import { checkCustomPasswordRules, complexityOptions } from '../utils/passwordRules.js';
+
+const schema = Joi.object({
+    name: Joi.string().required(),
+    email: Joi.string().email().required(),
+    password: passwordComplexity(complexityOptions).required(),
+});
+
+export const validateRegister = (req, res, next) => {
+    const { error } = schema.validate(req.body);
+    if (error) {
+        return res.status(400).json({
+            success: false,
+            message: error.details[0].message
+        });
+    }
+
+    const customRuleError = checkCustomPasswordRules(req.body.password);
+    if (customRuleError) {
+        return res.status(400).json({
+            success: false,
+            message: customRuleError
+        });
+    }
+
+    next();
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,12 +12,31 @@
         "bcryptjs": "^3.0.2",
         "cors": "^2.8.5",
         "express": "^5.1.0",
+        "joi-password-complexity": "^5.2.0",
         "jsonwebtoken": "^9.0.2",
-        "mongoose": "^8.17.0"
+        "mongoose": "^8.17.0",
+        "owasp-password-strength-test": "^1.3.0"
       },
       "devDependencies": {
         "dotenv": "^17.2.1",
         "supertest": "^7.1.4"
+      }
+    },
+    "node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
       }
     },
     "node_modules/@mongodb-js/saslprep": {
@@ -51,6 +70,30 @@
       "dependencies": {
         "@noble/hashes": "^1.1.5"
       }
+    },
+    "node_modules/@sideway/address": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
+      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@sideway/formula": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@types/webidl-conversions": {
       "version": "7.0.3",
@@ -710,6 +753,29 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
+    "node_modules/joi": {
+      "version": "17.13.3",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
+      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@hapi/hoek": "^9.3.0",
+        "@hapi/topo": "^5.1.0",
+        "@sideway/address": "^4.1.5",
+        "@sideway/formula": "^3.0.1",
+        "@sideway/pinpoint": "^2.0.0"
+      }
+    },
+    "node_modules/joi-password-complexity": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/joi-password-complexity/-/joi-password-complexity-5.2.0.tgz",
+      "integrity": "sha512-exQOcaKC4EuZwwNVQ/5/FcnCzdwdzjA2RPIrRgZXTjzkFhY5NUtP83SlcNSUK3OvbRFpjUq1FCzhHg/uqPg90g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "joi": ">= 17"
+      }
+    },
     "node_modules/jsonwebtoken": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
@@ -1029,6 +1095,12 @@
       "dependencies": {
         "wrappy": "1"
       }
+    },
+    "node_modules/owasp-password-strength-test": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/owasp-password-strength-test/-/owasp-password-strength-test-1.3.0.tgz",
+      "integrity": "sha512-33/Z+vyjlFaVZsT7aAFe3SkQZdU6su59XNkYdU5o2Fssz0D9dt6uiFaMm62M7dFQSKogULq8UYvdKnHkeqNB2w==",
+      "license": "MIT"
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -1418,6 +1490,21 @@
     }
   },
   "dependencies": {
+    "@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+      "peer": true
+    },
+    "@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "peer": true,
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
     "@mongodb-js/saslprep": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.3.0.tgz",
@@ -1440,6 +1527,27 @@
       "requires": {
         "@noble/hashes": "^1.1.5"
       }
+    },
+    "@sideway/address": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
+      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
+      "peer": true,
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@sideway/formula": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
+      "peer": true
+    },
+    "@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
+      "peer": true
     },
     "@types/webidl-conversions": {
       "version": "7.0.3",
@@ -1889,6 +1997,25 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
     },
+    "joi": {
+      "version": "17.13.3",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
+      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+      "peer": true,
+      "requires": {
+        "@hapi/hoek": "^9.3.0",
+        "@hapi/topo": "^5.1.0",
+        "@sideway/address": "^4.1.5",
+        "@sideway/formula": "^3.0.1",
+        "@sideway/pinpoint": "^2.0.0"
+      }
+    },
+    "joi-password-complexity": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/joi-password-complexity/-/joi-password-complexity-5.2.0.tgz",
+      "integrity": "sha512-exQOcaKC4EuZwwNVQ/5/FcnCzdwdzjA2RPIrRgZXTjzkFhY5NUtP83SlcNSUK3OvbRFpjUq1FCzhHg/uqPg90g==",
+      "requires": {}
+    },
     "jsonwebtoken": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
@@ -2091,6 +2218,11 @@
       "requires": {
         "wrappy": "1"
       }
+    },
+    "owasp-password-strength-test": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/owasp-password-strength-test/-/owasp-password-strength-test-1.3.0.tgz",
+      "integrity": "sha512-33/Z+vyjlFaVZsT7aAFe3SkQZdU6su59XNkYdU5o2Fssz0D9dt6uiFaMm62M7dFQSKogULq8UYvdKnHkeqNB2w=="
     },
     "parseurl": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,10 @@
     "bcryptjs": "^3.0.2",
     "cors": "^2.8.5",
     "express": "^5.1.0",
+    "joi-password-complexity": "^5.2.0",
     "jsonwebtoken": "^9.0.2",
-    "mongoose": "^8.17.0"
+    "mongoose": "^8.17.0",
+    "owasp-password-strength-test": "^1.3.0"
   },
   "devDependencies": {
     "dotenv": "^17.2.1",

--- a/routes/authentication.js
+++ b/routes/authentication.js
@@ -1,10 +1,11 @@
 import { Router } from "express";
 import { registerNewUser, loginUser } from "../controllers/authentication.js";
+import { validateRegister } from "../middlewares/validateRegister.js";
 
 const router = Router();
 
 // User registration route
-router.put("/register", registerNewUser);
+router.put("/register", validateRegister, registerNewUser);
 
 // User login route
 router.post("/login", loginUser);

--- a/utils/passwordRules.js
+++ b/utils/passwordRules.js
@@ -1,0 +1,42 @@
+import owasp from 'owasp-password-strength-test';
+
+owasp.config({
+  minLength: 0,
+  maxLength: 128,
+  allowPassphrases: true,
+  minOptionalTestsToPass: 0,
+});
+
+export const complexityOptions = {
+    min: parseInt(process.env.PASSWORD_MIN_LENGTH || '8'),
+    max: parseInt(process.env.PASSWORD_MAX_LENGTH || '128'),
+    lowerCase: parseInt(process.env.PASSWORD_MIN_LOWERCASE || '1'),
+    upperCase: parseInt(process.env.PASSWORD_MIN_UPPERCASE || '1'),
+    numeric: parseInt(process.env.PASSWORD_MIN_NUMBERS || '1'),
+    symbol: parseInt(process.env.PASSWORD_MIN_SYMBOLS || '1'),
+    requirementCount: parseInt(process.env.PASSWORD_REQUIREMENT_COUNT || '3')
+};
+
+export const checkCustomPasswordRules = (password) => {
+    const { errors } = owasp.test(password);
+
+    if (process.env.PASSWORD_BLOCK_COMMON === 'true') {
+        if (errors.some(e => e.toLowerCase().includes('common'))) {
+            return 'Password is too common. Please choose a stronger one.';
+        }
+    }
+
+    if (process.env.PASSWORD_BLOCK_SEQUENTIAL === 'true') {
+        if (errors.some(e => e.toLowerCase().includes('sequential'))) {
+            return 'Password contains sequential characters.';
+        }
+    }
+
+    if (process.env.PASSWORD_BLOCK_REPEATED === 'true') {
+        if (errors.some(e => e.toLowerCase().includes('repeated') || e.toLowerCase().includes('character'))) {
+            return 'Password contains repeated characters or patterns.';
+        }
+    }
+    
+    return null;
+};


### PR DESCRIPTION
This PR introduces a configurable password validation system that improves account security during user registration. 

Issue link: [#2](https://github.com/souptik4572/DigitalDialogue-backend/issues/2)

It enforces both structural and semantic password requirements, allowing administrators to control password policy via environment variables.

Structural Validation (using joi and joi-password-complexity)
Enforced rules based on the following environment variables:

> PASSWORD_MIN_LENGTH=8
> PASSWORD_MAX_LENGTH=128
> PASSWORD_MIN_LOWERCASE=1
> PASSWORD_MIN_UPPERCASE=1
> PASSWORD_MIN_NUMBERS=1
> PASSWORD_MIN_SYMBOLS=1
> PASSWORD_REQUIREMENT_COUNT=3


These values are passed to [joi-password-complexity](https://www.npmjs.com/package/joi-password-complexity) and integrated into the existing Joi validation flow.

Semantic Validation (using owasp-password-strength-test)
Installed via:
`npm install owasp-password-strength-test`

It is used to check passwords against common vulnerabilities, controlled via:

> PASSWORD_BLOCK_COMMON=true
> PASSWORD_BLOCK_SEQUENTIAL=true
> PASSWORD_BLOCK_REPEATED=true

File Structure Updates

- Added utils/passwordRules.js to encapsulate both Joi config and custom rule checks.
- Modified middleware/validateRegister.js to:
- Use joi-password-complexity for structural checks
- Use checkCustomPasswordRules() for semantic rules
- Updated route /register to include the new validation middleware.

Let me know if you notice anything that needs to be changed
